### PR TITLE
Chore/update deps may 2026

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "overrides": {
       "vite": "^6.2.3",
       "defu": "^6.1.7",
-      "postcss": "^8.5.3",
+      "postcss": "^8.5.10",
       "picomatch": "^4.0.4",
       "brace-expansion": "^5.0.0",
-      "lodash": "^4.17.21",
+      "lodash": "^4.18.0",
+      "fast-uri": "^3.1.2",
       "uuid": "^10.0.0"
     }
   }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -38,7 +38,7 @@
     "@hono/node-server": "^1.19.13",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
-    "hono": "^4.12.15",
+    "hono": "^4.12.18",
     "reflect-metadata": "^0.2.2",
     "zod": "^3.22.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,11 @@ settings:
 overrides:
   vite: ^6.2.3
   defu: ^6.1.7
-  postcss: ^8.5.3
+  postcss: ^8.5.10
   picomatch: ^4.0.4
   brace-expansion: ^5.0.0
-  lodash: ^4.17.21
+  lodash: ^4.18.0
+  fast-uri: ^3.1.2
   uuid: ^10.0.0
 
 importers:
@@ -745,7 +746,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.19.13
-        version: 1.19.14(hono@4.12.15)
+        version: 1.19.14(hono@4.12.18)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -756,8 +757,8 @@ importers:
         specifier: ^14.26.3
         version: 14.26.3
       hono:
-        specifier: ^4.12.15
-        version: 4.12.15
+        specifier: ^4.12.18
+        version: 4.12.18
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -2012,13 +2013,13 @@ packages:
     dev: true
     optional: true
 
-  /@hono/node-server@1.19.14(hono@4.12.15):
+  /@hono/node-server@1.19.14(hono@4.12.18):
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
     dev: false
 
   /@inquirer/ansi@2.0.4:
@@ -2876,7 +2877,7 @@ packages:
     engines: {node: '>=v16'}
     dependencies:
       fast-deep-equal: 3.1.3
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   /@sapphire/snowflake@3.5.3:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
@@ -3201,7 +3202,7 @@ packages:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     dev: true
@@ -3995,8 +3996,8 @@ packages:
       fast-string-truncated-width: 3.0.3
     dev: false
 
-  /fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  /fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
     dev: true
 
   /fast-wrap-ansi@0.2.0:
@@ -4236,6 +4237,11 @@ packages:
 
   /hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+    dev: false
+
+  /hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
     dev: false
 
@@ -4493,8 +4499,8 @@ packages:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
     dev: true
 
-  /lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  /lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   /loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -4827,8 +4833,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  /postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.11
@@ -5614,7 +5620,7 @@ packages:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.59.0
       tinyglobby: 0.2.15
       tsx: 4.21.0


### PR DESCRIPTION
## Summary

Bumps `lodash`, `postcss`, `fast-uri` (monorepo-level overrides) and `hono` (`@spraxium/http`) to their latest stable versions.

## Type of Change

- [x] Build / CI / tooling

## Related Issue

<!-- Closes #123 -->

## Changes

**`package.json` (pnpm overrides)**
- `lodash` `^4.17.21` → `^4.18.0`
- `postcss` `^8.5.3` → `^8.5.10`
- `fast-uri` `^3.1.2` _(new override, was unversioned transitive dep)_

**`packages/http/package.json`**
- `hono` `^4.12.15` → `^4.12.18`

## Testing

- [x] Existing tests pass
- [ ] New tests added where needed
- [x] Manually tested in the sandbox app

## Notes for Reviewers

All bumps are non-breaking patch/minor updates within the same major. The `fast-uri` override pins the transitive dependency pulled in by `ajv` (dev). The `lodash` override applies globally via pnpm overrides. No public API changes in any Spraxium package.

## Checklist

- [x] Code follows the project style (biome check passes)
- [x] TypeScript compiles without errors
- [x] No breaking public API changes without a deprecation path or version bump
- [ ] Documentation updated if behavior changed
