### PR TITLE
✨ feat(components): support dynamic buttons in V2 sections

### DIFF
--- a/apps/dynamic-bot/src/app.module.ts
+++ b/apps/dynamic-bot/src/app.module.ts
@@ -7,6 +7,7 @@ import { LeaderboardModule } from './modules/leaderboard/leaderboard.module';
 import { PanelModule } from './modules/panel/panel.module';
 import { QuickActionsModule } from './modules/quick-actions/quick-actions.module';
 import { RestyleModule } from './modules/restyle/restyle.module';
+import { TaskManagerModule } from './modules/task-manager/task-manager.module';
 import { TicketsModule } from './modules/tickets/tickets.module';
 import { TopicsModule } from './modules/topics/topics.module';
 import { WizardModule } from './modules/wizard/wizard.module';
@@ -24,6 +25,7 @@ import { WizardModule } from './modules/wizard/wizard.module';
     WizardModule,
     TicketsModule,
     ErrorsModule,
+    TaskManagerModule,
   ],
 })
 export class AppModule {}

--- a/apps/dynamic-bot/src/modules/task-manager/commands/task-manager.command.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/commands/task-manager.command.ts
@@ -1,0 +1,7 @@
+import { SlashCommand } from '@spraxium/common';
+
+@SlashCommand({
+  name: 'taskmanager',
+  description: 'Demo: dynamic sections (@DynamicSection + @ButtonPayload).',
+})
+export class TaskManagerCommand {}

--- a/apps/dynamic-bot/src/modules/task-manager/components/TaskList.container.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/components/TaskList.container.ts
@@ -1,0 +1,26 @@
+import { V2Container, V2Dynamic, V2Text, desc, v2row, v2section, v2sep } from '@spraxium/components';
+import { SeparatorSpacingSize } from 'discord.js';
+import { Task } from '../task-manager.data';
+import { ViewTaskButton } from './ViewTask.button';
+
+@V2Container({ accentColor: '#93ed7a' })
+export class TaskListContainer {
+  @V2Text(desc().h1('Task List'))
+  heading!: never;
+
+  @V2Dynamic((tasks: Task[]) => {
+    return tasks.flatMap((task) => {
+      return [
+        v2section({
+          text: task.description,
+          dynamic: {
+            button: ViewTaskButton,
+            item: task,
+          },
+        }),
+        v2sep({ spacing: SeparatorSpacingSize.Large }),
+      ];
+    });
+  })
+  tasks!: never;
+}

--- a/apps/dynamic-bot/src/modules/task-manager/components/ViewTask.button.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/components/ViewTask.button.ts
@@ -1,0 +1,16 @@
+import { ButtonRenderConfig, DynamicButton } from '@spraxium/components';
+import { Task } from '../task-manager.data';
+
+@DynamicButton({ baseId: 'view-task', encoding: 'inline' })
+export class ViewTaskButton {
+  static render(task: Task): ButtonRenderConfig {
+    return {
+      label: 'View',
+      style: 'primary',
+      emoji: '👁️',
+      params: {
+        id: task.id,
+      },
+    };
+  }
+}

--- a/apps/dynamic-bot/src/modules/task-manager/handlers/task-manager-command.handler.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/handlers/task-manager-command.handler.ts
@@ -1,0 +1,20 @@
+import { Ctx, SlashCommandHandler } from '@spraxium/common';
+import { V2Service } from '@spraxium/components';
+import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
+import { TaskManagerCommand } from '../commands/task-manager.command';
+import { TaskListContainer } from '../components/TaskList.container';
+import { TASKS } from '../task-manager.data';
+
+@SlashCommandHandler(TaskManagerCommand)
+export class TaskManagerHandler {
+  constructor(private readonly v2: V2Service) {}
+
+  async handle(@Ctx() interaction: ChatInputCommandInteraction): Promise<void> {
+    const payload = await this.v2.buildReply(TaskListContainer, TASKS);
+
+    await interaction.reply({
+      ...payload,
+      flags: payload.flags | MessageFlags.Ephemeral,
+    });
+  }
+}

--- a/apps/dynamic-bot/src/modules/task-manager/handlers/view-task.handler.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/handlers/view-task.handler.ts
@@ -1,0 +1,16 @@
+import { Ctx } from '@spraxium/common';
+import { ButtonParams, DynamicButtonHandler } from '@spraxium/components';
+import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
+import { ViewTaskButton } from '../components/ViewTask.button';
+
+@DynamicButtonHandler(ViewTaskButton)
+export class ViewTaskHandler {
+  async handle(
+    @Ctx() interaction: ChatInputCommandInteraction,
+    @ButtonParams() params: { id: string },
+  ): Promise<void> {
+    await interaction.reply({
+      content: `Button was clicked in section with id -> ${params.id}`,
+    });
+  }
+}

--- a/apps/dynamic-bot/src/modules/task-manager/task-manager.data.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/task-manager.data.ts
@@ -1,0 +1,74 @@
+export type TaskState = 'in_progress' | 'review' | 'todo' | 'done';
+
+export interface Task {
+  id: string;
+  description: string;
+  state: TaskState;
+  steps: string[];
+  due_date: Date;
+}
+
+export const TASKS: ReadonlyArray<Task> = [
+  {
+    id: 'task-001',
+    description: 'Implement authentication flow with JWT and refresh tokens',
+    state: 'in_progress',
+    steps: [
+      'Create login endpoint',
+      'Generate JWT access token',
+      'Implement refresh token storage',
+      'Add token validation middleware',
+      'Write integration tests',
+    ],
+    due_date: new Date('2026-05-20'),
+  },
+  {
+    id: 'task-002',
+    description: 'Design Discord V2 dynamic section components',
+    state: 'review',
+    steps: [
+      'Define V2Section config updates',
+      'Add dynamic button accessory support',
+      'Implement runtime builder logic',
+      'Write usage examples',
+      'Review API consistency',
+    ],
+    due_date: new Date('2026-05-18'),
+  },
+  {
+    id: 'task-003',
+    description: 'Refactor component dispatcher lifecycle',
+    state: 'todo',
+    steps: [
+      'Analyze dispatcher responsibilities',
+      'Extract guard execution layer',
+      'Reduce duplicated metadata lookups',
+      'Improve error handling',
+    ],
+    due_date: new Date('2026-05-27'),
+  },
+  {
+    id: 'task-004',
+    description: 'Create leaderboard UI for game server',
+    state: 'done',
+    steps: [
+      'Build leaderboard container',
+      'Add dynamic player buttons',
+      'Style medal rankings',
+      'Test Discord component rendering',
+    ],
+    due_date: new Date('2026-05-10'),
+  },
+  {
+    id: 'task-005',
+    description: 'Optimize payload storage expiration cleanup',
+    state: 'in_progress',
+    steps: [
+      'Inspect payload lifecycle',
+      'Add TTL cleanup scheduler',
+      'Prevent stale payload access',
+      'Benchmark memory usage',
+    ],
+    due_date: new Date('2026-05-23'),
+  },
+];

--- a/apps/dynamic-bot/src/modules/task-manager/task-manager.module.ts
+++ b/apps/dynamic-bot/src/modules/task-manager/task-manager.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@spraxium/common';
+import { TaskManagerCommand } from './commands/task-manager.command';
+import { TaskManagerHandler } from './handlers/task-manager-command.handler';
+import { ViewTaskHandler } from './handlers/view-task.handler';
+
+@Module({
+  commands: [TaskManagerCommand],
+  handlers: [TaskManagerHandler, ViewTaskHandler],
+})
+export class TaskManagerModule {}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,9 +46,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -47,9 +47,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,9 +64,7 @@
     "tsdown": "^0.12.0",
     "typescript": "^5.7.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/components/src/components/v2/interfaces/v2-component.interface.ts
+++ b/packages/components/src/components/v2/interfaces/v2-component.interface.ts
@@ -35,6 +35,11 @@ export interface V2SectionConfig {
   // biome-ignore lint/suspicious/noExplicitAny: generic callable type required
   text: string | DescriptionBuilder | ((data: any) => string | DescriptionBuilder);
   button?: AnyConstructor;
+  dynamic?: {
+    button: AnyConstructor;
+    // biome-ignore lint/suspicious/noExplicitAny: factory receives caller-defined data types
+    item?: unknown | ((data: any) => unknown);
+  };
   thumbnail?: V2ThumbnailConfig;
   i18n?: V2SectionI18nKeys;
 }

--- a/packages/components/src/components/v2/service/v2.service.ts
+++ b/packages/components/src/components/v2/service/v2.service.ts
@@ -229,7 +229,7 @@ export class V2Service {
         const rawText = typeof cfg.text === 'function' ? cfg.text(data) : cfg.text;
         const text = rawText instanceof DescriptionBuilder ? rawText.toString() : (rawText as string);
 
-        if (!cfg.button && !cfg.thumbnail) {
+        if (!cfg.button && !cfg.thumbnail && !cfg.dynamic) {
           return new TextDisplayBuilder().setContent(text);
         }
 
@@ -241,6 +241,24 @@ export class V2Service {
           if (cfg.thumbnail.description) t.setDescription(cfg.thumbnail.description);
           if (cfg.thumbnail.spoiler) t.setSpoiler(true);
           sec.setThumbnailAccessory(t);
+        } else if (cfg.dynamic) {
+          if (!allowAsync) {
+            throw new Error(
+              '[V2Service] @V2Section with dynamic button requires async build(). Use V2Service.build() instead of buildSync().',
+            );
+          }
+
+          const item =
+            typeof cfg.dynamic.item === 'function' ? cfg.dynamic.item(data) : (cfg.dynamic.item ?? data);
+
+          return this.buttons.buildDynamicButtons(cfg.dynamic.button, [item], context).then(([button]) => {
+            if (!button) {
+              throw new Error('[V2Service] @V2Section dynamic button produced no button.');
+            }
+
+            sec.setButtonAccessory(button);
+            return sec;
+          });
         } else if (cfg.button) {
           const row = this.buttons.build(
             cfg.button,
@@ -316,18 +334,37 @@ export class V2Service {
 
       case 'dynamic': {
         const cfg = child.config as V2DynamicConfig;
-        return cfg.factory(data).flatMap((spec) => {
-          const result = this.buildChild(
-            { ...spec, propertyKey: '__dynamic__', order: -1 } as V2ChildDef,
-            data,
-            context,
-            allowAsync,
-          );
-          if (result instanceof Promise) {
-            throw new Error('[V2Service] @V2Dynamic factories may not produce async children.');
-          }
-          return result;
-        }) as Array<V2InnerBuilder>;
+        const specs = cfg.factory(data);
+
+        if (!allowAsync) {
+          return specs.flatMap((spec) => {
+            const result = this.buildChild(
+              { ...spec, propertyKey: '__dynamic__', order: -1 } as V2ChildDef,
+              data,
+              context,
+              false,
+            );
+
+            if (result instanceof Promise) {
+              throw new Error(
+                '[V2Service] @V2Dynamic produced async children. Use V2Service.build() instead of buildSync().',
+              );
+            }
+
+            return result;
+          }) as Array<V2InnerBuilder>;
+        }
+
+        return Promise.all(
+          specs.map((spec) =>
+            this.buildChild(
+              { ...spec, propertyKey: '__dynamic__', order: -1 } as V2ChildDef,
+              data,
+              context,
+              true,
+            ),
+          ),
+        ).then((results) => results.flat());
       }
 
       case 'dynamicRow': {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,9 +51,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -42,9 +42,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -56,9 +56,7 @@
     "tsdown": "^0.12.0",
     "typescript": "^5.7.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -60,9 +60,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -3,15 +3,7 @@
   "version": "0.2.2",
   "private": false,
   "description": "Centralized structured logging system for the Spraxium ecosystem",
-  "keywords": [
-    "discord",
-    "discord-bot",
-    "spraxium",
-    "typescript",
-    "logger",
-    "logging",
-    "bot-framework"
-  ],
+  "keywords": ["discord", "discord-bot", "spraxium", "typescript", "logger", "logging", "bot-framework"],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -35,9 +27,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -59,9 +59,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/signal-client/package.json
+++ b/packages/signal-client/package.json
@@ -42,9 +42,7 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/signal/package.json
+++ b/packages/signal/package.json
@@ -48,9 +48,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/webhook/package.json
+++ b/packages/webhook/package.json
@@ -51,9 +51,7 @@
     "tsdown": "^0.12.0",
     "typescript": "^5.7.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

V2 sections should support dynamic button accessories, including inline params handling, similarly to dynamic rows.

## Type of Change

- [x] Bug fix
- [x] New feature

## Changes

- Added `dynamic` support to `V2SectionConfig`
- Updated `V2Service` to build dynamic button accessories
- Updated `@V2Dynamic` handling to support async child builders
- Added a `dynamic-bot` example with task sections and dynamic buttons

## Testing

- [x] Manually tested in the sandbox app

Created a new module in the `dynamic-bot` app.

The example creates a task manager module that renders multiple V2 sections dynamically from task data.  
Each section includes a dynamic button accessory generated from a `@DynamicButton`.


When clicked, the dynamic button handler replies with a message containing the task identifier.

## Screenshots
<img width="802" height="792" alt="image" src="https://github.com/user-attachments/assets/44b5f901-a7ff-4452-a329-eadb6aad4915" />


## Notes for Reviewers

- Dynamic section accessories were tested using inline-encoded dynamic buttons
- The functional `item: (data) => ...` resolver path has not been explicitly tested yet

## Checklist

- [x] Code follows the project style (`biome check` passes)
- [x] TypeScript compiles without errors
- [x] No breaking public API changes without a deprecation path or version bump
- [ ] Documentation updated if behavior changed