### PR TITLE
🐛 fix(components): restore runtime import for PayloadService in Modal…

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,9 +64,7 @@
     "tsdown": "^0.12.0",
     "typescript": "^5.7.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/components/src/components/modal/service/modal.service.ts
+++ b/packages/components/src/components/modal/service/modal.service.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { Injectable } from '@spraxium/common';
 import type { ModalBuilder, ModalSubmitInteraction } from 'discord.js';
 import { COMPONENT_METADATA_KEYS } from '../../../component-metadata-keys.constant';
-import type { PayloadService } from '../../../runtime/payload';
+// biome-ignore lint/style/useImportType: needed for DI runtime injection
+import { PayloadService } from '../../../runtime/payload';
 import type { AnyConstructor } from '../../../types';
 import { type InlineParams, encodeInlineParams, joinCustomId } from '../../../utils/custom-id';
 import { ModalFieldCache } from '../cache';
@@ -55,7 +56,9 @@ export class ModalService {
     options?: { ttl?: number; data?: T },
   ): Promise<ModalBuilder> {
     const meta = this.getComponentMeta(ModalClass);
-    const envelope = await this.payloads.create(payload, { ttl: options?.ttl ?? 900 });
+    const envelope = await this.payloads.create(payload, {
+      ttl: options?.ttl ?? 900,
+    });
     const customId = joinCustomId(meta.id, { payloadId: envelope.id });
     const built = this.renderer.render(
       this.schema.build(ModalClass, options?.data as Record<string, unknown>),

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -60,9 +60,7 @@
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🐛 Fix DI resolution for `PayloadService` in `ModalService`

## Summary

Fixes a dependency injection issue where `PayloadService` was incorrectly resolved as `Object`, causing runtime instantiation failures in `ModalService`.

## Type of Change

- [x] Bug fix

## Related Issue

<!-- Closes #123 -->
N/A

## Changes

- Replaced `import type { PayloadService }` with a runtime import in `ModalService`
- Added Biome inline ignore for `useImportType` rule to allow DI-compatible import
- Ensured `PayloadService` is available at runtime for constructor metadata resolution

## Testing

- [x] Existing runtime flow tested manually (modal-bot startup)
- [x] Verified DI container resolves `PayloadService` correctly
- [ ] Existing tests pass
- [ ] New tests added where needed

## Notes for Reviewers

This is a known edge case where lint rules enforcing `import type` conflict with DI frameworks relying on `reflect-metadata`.

Without this change, constructor metadata collapses to `Object`, breaking service instantiation.

## Checklist

- [x] Code follows the project style (biome check passes with ignore)
- [x] TypeScript compiles without errors
- [x] No breaking public API changes
- [ ] Documentation updated if behavior changed